### PR TITLE
Keep selection for manual copy, do not paste & select

### DIFF
--- a/src/js/bwr_calc.js
+++ b/src/js/bwr_calc.js
@@ -275,10 +275,12 @@ var cCalc = (function (window, document) {
 
 					// caclulate new location for insertion (so results are inserted from left to right)
 					calcSelStart = calcSelEnd = calcSelStart + resultText.length;
-					$calcInput.val(head + resultText + tail);
+					if (!window.getSelection().toString()) {
+						$calcInput.val(head + resultText + tail);
 
 					// focus calc input
-					$calcInput.focus();
+						$calcInput.focus();
+					}
 
 					// set caret to end of inserted result
 					$calcInput[0].selectionStart = $calcInput[0].selectionEnd = calcSelStart;
@@ -289,7 +291,11 @@ var cCalc = (function (window, document) {
 			});
 
 			// refocus calc input no matter where user clicks
-			$(document).click(function () {$calcInput.focus();});
+			$(document).click(function () {
+				if (!window.getSelection().toString()) {
+					$calcInput.focus();
+				}
+			});
 			$calcResultsWrapper.scroll(function () {$calcInput.focus();});			
 		});
 	}


### PR DESCRIPTION
If on `click` there is a selection (user selected some part of the expression/result) - do not paste that part into input and do not blur the selection - this will allow user to copy-paste that selection easily.